### PR TITLE
NXCT-307: add server IDs

### DIFF
--- a/jenkins-build/slave-maven/settings.xml
+++ b/jenkins-build/slave-maven/settings.xml
@@ -16,6 +16,21 @@
       <username>${env.NEXUS_ADMIN_USERNAME}</username>
       <password>${env.NEXUS_ADMIN_PASSWORD}</password>
     </server>
+    <server>
+      <id>maven-hotfix</id>
+      <username>${env.HOTFIX_RELEASE_USERNAME}</username>
+      <password>${env.HOTFIX_RELEASE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>maven-private</id>
+      <username>${env.HOTFIX_RELEASE_USERNAME}</username>
+      <password>${env.HOTFIX_RELEASE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>maven-internal</id>
+      <username>${env.HOTFIX_RELEASE_USERNAME}</username>
+      <password>${env.HOTFIX_RELEASE_PASSWORD}</password>
+    </server>
   </servers>
   <profiles>
     <profile>


### PR DESCRIPTION
Add maven-hotfix, maven-private, maven-internal IDs.

A lot of others are eventually missing but this should be enough to circumvent some blockers.

Other mirrors should be added but https://maven-ncp.packages.nuxeo.com appears not being up to date.