### PR TITLE
NXCT-606: bind NUXEO_URL value to a configuration

### DIFF
--- a/nuxeo-init-container/bind.sh
+++ b/nuxeo-init-container/bind.sh
@@ -184,10 +184,16 @@ if [ -d $BINDINGS_DIR/custom ]; then
   fi
 fi
 
-if [ ! -z "$NUXEO_CLUSTERING" ]; then
+if [ ! -z "$NUXEO_CLUSTERING"  ]; then
   CONFFILE=$CONFD_DIR/10-clustering.conf
-  echo "nuxeo.cluster.enabled=true" > $CONFFILE
+  echo "nuxeo.cluster.enabled=${NUXEO_CLUSTERING}" > $CONFFILE
   if [ ! -z "NUXEO_NODE_ID" ]; then
     echo "nuxeo.cluster.nodeid=${NUXEO_NODE_ID}" >> $CONFFILE
   fi
+fi
+
+
+if [ ! -z "$NUXEO_URL"  ]; then
+  CONFFILE=$CONFD_DIR/10-url.conf
+  echo "nuxeo.url=${NUXEO_URL}" > $CONFFILE  
 fi

--- a/nuxeo-init-container/test.sh
+++ b/nuxeo-init-container/test.sh
@@ -138,6 +138,14 @@ testClusteringOn() {
 testClusteringOff() {
     runInit -e NUXEO_CLUSTERING=false
 
-    assertFalse "Clustering configuration is not found" '[[ -f "target/conf.d/10-clustering.conf" ]]'
+    conf="$(cat target/conf.d/10-clustering.conf)"
+    assertContains "Clustering configuration is enabled"  "$conf" "nuxeo.cluster.enabled=false"
 
+}
+
+
+testNuxeoUrl() {
+    runInit -e NUXEO_URL=https://mysite.com:8080/nuxeo    
+    conf="$(cat target/conf.d/10-url.conf)"
+    assertContains "Nuxeo URL is set"  "$conf" "nuxeo.url=https://mysite.com:8080/nuxeo"
 }


### PR DESCRIPTION
Added `NUXEO_URL` binding and fixed a failing test around nuxeo clustering